### PR TITLE
Authentication for FE

### DIFF
--- a/inkvBE/Program.cs
+++ b/inkvBE/Program.cs
@@ -50,6 +50,18 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
+// CORS policy
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowSpecificOrigin", builder =>
+    {
+        builder.WithOrigins("http://localhost:5173")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
+
 // Read environmental variables
 var server = Environment.GetEnvironmentVariable("DB_SERVER");
 var database = Environment.GetEnvironmentVariable("POSTGRES_DB");
@@ -80,11 +92,11 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseCors("AllowSpecificOrigin");
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-
 
 
 

--- a/inkvBE/package-lock.json
+++ b/inkvBE/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "inkvBE",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/inkvFE/inkvFE/src/App.tsx
+++ b/inkvFE/inkvFE/src/App.tsx
@@ -7,18 +7,23 @@ import BlogPage from "@/pages/blog";
 import AboutPage from "@/pages/about";
 import LoginPage from "./pages/Login";
 import RegisterPage from "./pages/Register";
+import { AuthContextProvider } from "./contexts/auth";
+import PublicRoute from "./components/auth/PublicRoute";
+import PrivateRoute from "./components/auth/PrivateRoute";
 
 function App() {
   return (
-    <Routes>
-      <Route element={<IndexPage />} path="/" />
-      <Route element={<DocsPage />} path="/docs" />
-      <Route element={<PricingPage />} path="/pricing" />
-      <Route element={<BlogPage />} path="/blog" />
-      <Route element={<AboutPage />} path="/about" />
-      <Route element={<LoginPage />} path="login" />
-      <Route element={<RegisterPage />} path="register" />
-    </Routes>
+    <AuthContextProvider>
+      <Routes>
+        <Route element={<IndexPage/>} path="/"/>
+        <Route element={<DocsPage/>} path="/docs" />
+        <Route element={<PricingPage/>} path="/pricing" />
+        <Route element={<BlogPage/>} path="/blog" />
+        <Route element={<PrivateRoute> <AboutPage/> </PrivateRoute>} path="/about" />
+        <Route element={<PublicRoute> <LoginPage/> </PublicRoute>} path="login" />
+        <Route element={<PublicRoute> <RegisterPage/> </PublicRoute>} path="register" />
+      </Routes>
+    </AuthContextProvider>
   );
 }
 

--- a/inkvFE/inkvFE/src/components/auth/PrivateRoute.tsx
+++ b/inkvFE/inkvFE/src/components/auth/PrivateRoute.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import React from "react";
+import { useAuth } from "@/contexts/auth";
+import { useNavigate } from "react-router-dom";
+import ROUTES from "@/enums/routes";
+
+type PrivateRouteProps = {
+  children: ReactNode;
+}
+
+const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if(!isAuthenticated) {
+      navigate(ROUTES.LOGIN, {replace: true});
+    }
+  }, [isAuthenticated, navigate]);
+
+  return isAuthenticated ? children : null;
+}
+
+export default PrivateRoute;

--- a/inkvFE/inkvFE/src/components/auth/PublicRoute.tsx
+++ b/inkvFE/inkvFE/src/components/auth/PublicRoute.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import React from "react";
+import { useAuth } from "@/contexts/auth";
+import { useNavigate } from "react-router-dom";
+import ROUTES from "@/enums/routes";
+
+type PublicRouteProps = {
+  children: ReactNode;
+}
+
+const PublicRoute: React.FC<PublicRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if(isAuthenticated) {
+      navigate(ROUTES.HOME, {replace: true});
+    }
+  }, [isAuthenticated, navigate]);
+
+  return !isAuthenticated ? children : null;
+}
+
+export default PublicRoute;

--- a/inkvFE/inkvFE/src/components/icons.tsx
+++ b/inkvFE/inkvFE/src/components/icons.tsx
@@ -8,18 +8,18 @@ export const Logo: React.FC<IconSvgProps> = ({
   ...props
 }) => (
   <svg
-    fill="none"
-    height={size || height}
-    viewBox="0 0 32 32"
-    width={size || height}
+    width="24px"
+    height="24px"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none" stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round" 
     {...props}
   >
-    <path
-      clipRule="evenodd"
-      d="M17.6482 10.1305L15.8785 7.02583L7.02979 22.5499H10.5278L17.6482 10.1305ZM19.8798 14.0457L18.11 17.1983L19.394 19.4511H16.8453L15.1056 22.5499H24.7272L19.8798 14.0457Z"
-      fill="currentColor"
-      fillRule="evenodd"
-    />
+    <line x1="12" y1="1" x2="12" y2="23"></line>
+    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
   </svg>
 );
 

--- a/inkvFE/inkvFE/src/components/navbar.tsx
+++ b/inkvFE/inkvFE/src/components/navbar.tsx
@@ -1,144 +1,37 @@
-import { Button } from "@heroui/button";
-import { Kbd } from "@heroui/kbd";
 import { Link } from "@heroui/link";
-import { Input } from "@heroui/input";
 import {
   Navbar as HeroUINavbar,
   NavbarBrand,
-  NavbarContent,
-  NavbarItem,
-  NavbarMenuToggle,
-  NavbarMenu,
-  NavbarMenuItem,
+  NavbarContent
 } from "@heroui/navbar";
-import { link as linkStyles } from "@heroui/theme";
-import clsx from "clsx";
-
-import { siteConfig } from "@/config/site";
-import { ThemeSwitch } from "@/components/theme-switch";
-import {
-  TwitterIcon,
-  GithubIcon,
-  DiscordIcon,
-  HeartFilledIcon,
-  SearchIcon,
-} from "@/components/icons";
 import { Logo } from "@/components/icons";
 
 export const Navbar = () => {
-  const searchInput = (
-    <Input
-      aria-label="Search"
-      classNames={{
-        inputWrapper: "bg-default-100",
-        input: "text-sm",
-      }}
-      endContent={
-        <Kbd className="hidden lg:inline-block" keys={["command"]}>
-          K
-        </Kbd>
-      }
-      labelPlacement="outside"
-      placeholder="Search..."
-      startContent={
-        <SearchIcon className="text-base text-default-400 pointer-events-none flex-shrink-0" />
-      }
-      type="search"
-    />
-  );
+ 
 
   return (
     <HeroUINavbar maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand className="gap-3 max-w-fit">
           <Link
-            className="flex justify-start items-center gap-1"
+            className="flex justify-start items-center gap-1 "
             color="foreground"
             href="/"
           >
-            <Logo />
-            <p className="font-bold text-inherit">ACME</p>
+            <div className="bg-rose-500"><Logo /></div>
+            <p className="font-bold text-inherit">Skelbiu</p>
           </Link>
         </NavbarBrand>
-        <div className="hidden lg:flex gap-4 justify-start ml-2">
-          {siteConfig.navItems.map((item) => (
-            <NavbarItem key={item.href}>
-              <Link
-                className={clsx(
-                  linkStyles({ color: "foreground" }),
-                  "data-[active=true]:text-primary data-[active=true]:font-medium",
-                )}
-                color="foreground"
-                href={item.href}
-              >
-                {item.label}
-              </Link>
-            </NavbarItem>
-          ))}
-        </div>
-      </NavbarContent>
-
-      <NavbarContent
-        className="hidden sm:flex basis-1/5 sm:basis-full"
-        justify="end"
-      >
-        <NavbarItem className="hidden sm:flex gap-2">
-          <Link isExternal href={siteConfig.links.twitter} title="Twitter">
-            <TwitterIcon className="text-default-500" />
-          </Link>
-          <Link isExternal href={siteConfig.links.discord} title="Discord">
-            <DiscordIcon className="text-default-500" />
-          </Link>
-          <Link isExternal href={siteConfig.links.github} title="GitHub">
-            <GithubIcon className="text-default-500" />
-          </Link>
-          <ThemeSwitch />
-        </NavbarItem>
-        <NavbarItem className="hidden lg:flex">{searchInput}</NavbarItem>
-        <NavbarItem className="hidden md:flex">
-          <Button
-            isExternal
-            as={Link}
-            className="text-sm font-normal text-default-600 bg-default-100"
-            href={siteConfig.links.sponsor}
-            startContent={<HeartFilledIcon className="text-danger" />}
-            variant="flat"
+        <NavbarBrand className="gap-3 max-w-fit">
+          <Link
+            className="flex justify-start items-center gap-1 "
+            color="foreground"
+            href="/"
           >
-            Sponsor
-          </Button>
-        </NavbarItem>
+            PLaceHolder
+          </Link>
+        </NavbarBrand>
       </NavbarContent>
-
-      <NavbarContent className="sm:hidden basis-1 pl-4" justify="end">
-        <Link isExternal href={siteConfig.links.github}>
-          <GithubIcon className="text-default-500" />
-        </Link>
-        <ThemeSwitch />
-        <NavbarMenuToggle />
-      </NavbarContent>
-
-      <NavbarMenu>
-        {searchInput}
-        <div className="mx-4 mt-2 flex flex-col gap-2">
-          {siteConfig.navMenuItems.map((item, index) => (
-            <NavbarMenuItem key={`${item}-${index}`}>
-              <Link
-                color={
-                  index === 2
-                    ? "primary"
-                    : index === siteConfig.navMenuItems.length - 1
-                      ? "danger"
-                      : "foreground"
-                }
-                href="#"
-                size="lg"
-              >
-                {item.label}
-              </Link>
-            </NavbarMenuItem>
-          ))}
-        </div>
-      </NavbarMenu>
     </HeroUINavbar>
   );
 };

--- a/inkvFE/inkvFE/src/contexts/auth.tsx
+++ b/inkvFE/inkvFE/src/contexts/auth.tsx
@@ -1,0 +1,63 @@
+import React, { createContext, ReactNode } from "react";
+
+// Data stored in the context
+type AuthContextType = {
+  isAuthenticated: boolean;
+};
+
+// Default data
+const AuthContext = createContext<AuthContextType>({ 
+  isAuthenticated: false,
+});
+
+// Wrapper props
+type AuthContextProviderProps = {
+  children: ReactNode;
+}
+
+// Wrapper
+const AuthContextProvider: React.FC<AuthContextProviderProps> = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = React.useState<boolean>(false);
+
+  // Ping function
+  const ping = async() => {
+      try {
+        const res = await fetch("http://localhost:5126/api/auth/ping-me", { 
+          method: 'GET',
+          credentials: "include"
+        });
+        console.log(res.body);
+        console.log(res.status);
+        if (res.status == 200) {
+          setIsAuthenticated(true);
+          console.log("Authentication successful");   // Explicitly for debugging, ought to be removed later
+          return;
+        } else {
+          throw new Error();
+        }
+      } catch (err: any) {
+        setIsAuthenticated(false);
+        console.log("Authentication failed");   // Explicitly for debugging, ought to be removed later
+      }
+  }
+
+  // Call ping on mount
+  React.useEffect(() => {
+    console.log("Attempting to authenticated...");
+    ping();
+    console.log("Done authenticating!");
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ 
+      isAuthenticated: isAuthenticated
+    }}>
+      {children}
+    </AuthContext.Provider>
+  )
+};
+
+// Simplified interface for accessing the context
+const useAuth = () => React.useContext(AuthContext);
+
+export { useAuth, AuthContextProvider }

--- a/inkvFE/inkvFE/src/enums/routes.ts
+++ b/inkvFE/inkvFE/src/enums/routes.ts
@@ -1,0 +1,7 @@
+enum ROUTES {
+  HOME = "/",
+  LOGIN = "/login",
+  REGISTER = "/register",
+}
+
+export default ROUTES;


### PR DESCRIPTION
### Changes made:
- Created a context for authentication in `src/contexts/auth.tsx` and wrapped the app within it
- Added two wrapper components for routes: **PublicRoutes** and **PrivateRoutes**. The former is used to secure routes, that authenticated users couldn't access and vice versa. Located at `src/components/auth/`.
- Created an Enum to store accessible routes in `src/enums/routes.ts`.

### Proof of life
Since there's <ins>no</ins> login implementation for the login & register parts, we have to work around by making a **Postman** request to the `api/register` endpoint, copying the cookie and inserting into the browser.

Attaching the cookie:
![image](https://github.com/user-attachments/assets/d7a1fc08-cf97-47c0-aeab-6a7047761621)

Reloading the page:
![image](https://github.com/user-attachments/assets/f89973b7-c2c9-43a0-81c8-fb784b48cf65)

Removing the cookie and reloading the page:
![image](https://github.com/user-attachments/assets/fdbce396-c53c-4065-b4ea-3fe6666de591)
